### PR TITLE
[ADD] Boton pointer quitado de todas las cards - divs inecesarios

### DIFF
--- a/front-end/enbalde/src/app/pages/home/home.component.css
+++ b/front-end/enbalde/src/app/pages/home/home.component.css
@@ -17,23 +17,20 @@ img{
   }
   .card{
     transition:0.5s;
-    cursor:pointer;
   }
   .card-title{  
     font-size:15px;
     transition:1s;
-    cursor:pointer;
   }
   .card-title i{  
     font-size:15px;
     transition:1s;
-    cursor:pointer;
+
     color:#ffa710
   }
   .card-title i:hover{
     transform: scale(1.25) rotate(100deg); 
     color:#18d4ca;
-    
   }
   .card:hover{
     transform: scale(1.05);


### PR DESCRIPTION
Al ser una tarea que estaba ligada a las card de arriba(tambien tenian cursor:pointer) y a su vez estas heredaban los stylos, al sacar el pointer de una clase se quitaron de todas. Por ende son dos issues en una, asi que voy a cerrar la otra.