### PR TITLE
Arreglos backend

### DIFF
--- a/back-end/django/enbalde/serializers.py
+++ b/back-end/django/enbalde/serializers.py
@@ -60,6 +60,7 @@ class TipoArticuloSerializer(serializers.ModelSerializer):
         fields = ['id', 'nombre']
 
 
+
 class ArticuloSerializer(serializers.ModelSerializer):
     imagen = serializers.ImageField(max_length=None, allow_empty_file=False, use_url=True)
     tipo = TipoArticuloSerializer()

--- a/back-end/django/enbalde/urls.py
+++ b/back-end/django/enbalde/urls.py
@@ -1,9 +1,34 @@
-from django.urls import path
+from django.urls import path, include
+from rest_framework import routers, viewsets
+from .models import Usuario, Articulo, TipoArticulo
+from .serializers import UsuarioSerializer, ArticuloSerializer, TipoArticuloSerializer
 from .views.usuario_views import LoginView, LogoutView, SignupView
 from .views.articulo_views import MuchosArticulos, UnArticulo
 from .views.tipo_articulo_views import MuchosTiposArticulos, UnTipoArticulo
+from .models import Usuario
+
+
+class UsuarioViewSet(viewsets.ModelViewSet):
+    queryset = Usuario.objects.all()
+    serializer_class = UsuarioSerializer
+
+
+class ArticuloViewSet(viewsets.ModelViewSet):
+    queryset = Articulo.objects.all()
+    serializer_class = ArticuloSerializer
+
+
+class TipoArticuloViewSet(viewsets.ModelViewSet):
+    queryset = TipoArticulo.objects.all()
+    serializer_class = TipoArticuloSerializer
+
+
+router = routers.DefaultRouter()
+router.register('usuarios', UsuarioViewSet)
+
 
 urlpatterns = [
+    path('', include(router.urls)),
     path('auth/login/', LoginView.as_view(), name='auth_login'),
     path('auth/logout/', LogoutView.as_view(), name='auth_logout'),
     path('auth/signup/', SignupView.as_view(), name='auth_signup'),

--- a/back-end/django/enbalde/urls.py
+++ b/back-end/django/enbalde/urls.py
@@ -25,6 +25,7 @@ class TipoArticuloViewSet(viewsets.ModelViewSet):
 
 router = routers.DefaultRouter()
 router.register('usuarios', UsuarioViewSet)
+router.register('tipo_articulos', TipoArticuloViewSet)
 
 
 urlpatterns = [
@@ -34,6 +35,5 @@ urlpatterns = [
     path('auth/signup/', SignupView.as_view(), name='auth_signup'),
     path('articulos/', MuchosArticulos.as_view()),
     path('articulos/<int:pk>', UnArticulo.as_view()),
-    path('tipo_articulos/', MuchosTiposArticulos.as_view()),
     path('tipo_articulos/<int:pk>', UnTipoArticulo.as_view())
 ]

--- a/back-end/django/enbalde/urls.py
+++ b/back-end/django/enbalde/urls.py
@@ -1,10 +1,14 @@
 from django.urls import path
 from .views.usuario_views import LoginView, LogoutView, SignupView
-#from .views.jwt_token import TokenObtainPairView
+from .views.articulo_views import MuchosArticulos, UnArticulo
+from .views.tipo_articulo_views import MuchosTiposArticulos, UnTipoArticulo
 
 urlpatterns = [
     path('auth/login/', LoginView.as_view(), name='auth_login'),
     path('auth/logout/', LogoutView.as_view(), name='auth_logout'),
     path('auth/signup/', SignupView.as_view(), name='auth_signup'),
-    #path('auth/token/', TokenObtainPairView.as_view(), name='token_obtain_pair')
+    path('articulos/', MuchosArticulos.as_view()),
+    path('articulos/<int:pk>', UnArticulo.as_view()),
+    path('tipo_articulos/', MuchosTiposArticulos.as_view()),
+    path('tipo_articulos/<int:pk>', UnTipoArticulo.as_view())
 ]

--- a/back-end/django/enbalde/urls.py
+++ b/back-end/django/enbalde/urls.py
@@ -4,7 +4,7 @@ from .models import Usuario, Articulo, TipoArticulo
 from .serializers import UsuarioSerializer, ArticuloSerializer, TipoArticuloSerializer
 from .views.usuario_views import LoginView, LogoutView, SignupView
 from .views.articulo_views import MuchosArticulos, UnArticulo
-from .views.tipo_articulo_views import MuchosTiposArticulos, UnTipoArticulo
+from .views.tipo_articulo_views import UnTipoArticulo
 from .models import Usuario
 
 

--- a/back-end/django/enbalde/views/tipo_articulo_views.py
+++ b/back-end/django/enbalde/views/tipo_articulo_views.py
@@ -7,25 +7,6 @@ from rest_framework import status
 from .common import crear_respuesta
 
 
-class MuchosTiposArticulos(APIView):
-    def get(self, request: Request, format=None):
-        tipo_articulos = TipoArticulo.objects.all()
-        serializer = TipoArticuloSerializer(tipo_articulos, many=True)
-        return crear_respuesta("Tipos de artículos retornados exitosamente", serializer.data)
-
-    def post(self, request: Request, format=None):
-        try:
-            serializer = TipoArticuloSerializer(data=request.data)
-            if serializer.is_valid():
-                serializer.save()
-                return crear_respuesta("Tipo de artículo creado exitosamente", serializer.data, status.HTTP_201_CREATED)
-
-            return crear_respuesta("Error creando tipo de artículo", serializer.errors, status.HTTP_400_BAD_REQUEST)
-
-        except Exception as ex:
-            return crear_respuesta("Error creando tipo de artículo", str(ex), status.HTTP_400_BAD_REQUEST)
-
-
 class UnTipoArticulo(APIView):
     def _get_object(self, pk):
         try:

--- a/back-end/django/server/urls.py
+++ b/back-end/django/server/urls.py
@@ -44,10 +44,6 @@ router.register(r'api/usuarios', UsuarioViewSet)
 
 urlpatterns = [
     path('admin/', admin.site.urls),
-    path('api/', include('enbalde.urls')),
-    path('api/articulos/', articulo_views.MuchosArticulos.as_view()),
-    path('api/articulos/<int:pk>', articulo_views.UnArticulo.as_view()),
-    path('api/tipo_articulos/', tipo_articulo_views.MuchosTiposArticulos.as_view()),
-    path('api/tipo_articulos/<int:pk>', tipo_articulo_views.UnTipoArticulo.as_view()),
-    path('', include(router.urls))
+    path('', include(router.urls)),
+    path('api/', include('enbalde.urls'))
 ] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)

--- a/back-end/django/server/urls.py
+++ b/back-end/django/server/urls.py
@@ -18,32 +18,9 @@ from django.urls import path, include
 from django.contrib import admin
 from django.conf import settings
 from django.conf.urls.static import static
-from rest_framework import routers, viewsets
-from enbalde.views import articulo_views, tipo_articulo_views
-from enbalde.models import Usuario, Articulo, TipoArticulo
-from enbalde.serializers import UsuarioSerializer, ArticuloSerializer, TipoArticuloSerializer
 
-
-class UsuarioViewSet(viewsets.ModelViewSet):
-    queryset = Usuario.objects.all()
-    serializer_class = UsuarioSerializer
-
-
-class ArticuloViewSet(viewsets.ModelViewSet):
-    queryset = Articulo.objects.all()
-    serializer_class = ArticuloSerializer
-
-
-class TipoArticuloViewSet(viewsets.ModelViewSet):
-    queryset = TipoArticulo.objects.all()
-    serializer_class = TipoArticuloSerializer
-
-
-router = routers.DefaultRouter()
-router.register(r'api/usuarios', UsuarioViewSet)
 
 urlpatterns = [
     path('admin/', admin.site.urls),
-    path('', include(router.urls)),
     path('api/', include('enbalde.urls'))
 ] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)

--- a/front-end/enbalde/src/app/services/productos.service.ts
+++ b/front-end/enbalde/src/app/services/productos.service.ts
@@ -85,8 +85,8 @@ export class ProductosService {
   }
 
   obtenerTipos(): Observable<TipoProducto[]> {
-    return this.http.get<ResultadoApi>(this.tiposProductosUrl)
-      .pipe(map(response => response.data as TipoProducto[]));
+    return this.http.get<TipoProducto[]>(this.tiposProductosUrl)
+      .pipe(map(response => response as TipoProducto[]));
   }
 
   borrarTipo(tipoProducto: TipoProducto): Observable<ResultadoApi> {


### PR DESCRIPTION
Cambiar tipos_articulos a router con ViewSet en lugar de responder con un RespuestaApi para simplificar. Limpieza de redireccionamiento de las urls de las api.